### PR TITLE
Add support for different formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ mvn package assembly:single
 ## Run
 ```
 java -jar target/sparql-endpoint-0.0.1-SNAPSHOT-jar-with-dependencies.jar -h
-usage: sparql-endpoint [file1 [file2 ...] [-f <arg>] [-h] [-p <arg>]
- -f,--format <arg>   the format of the files. One of 'RDF/XML',
-                     'N-TRIPLE', 'TURTLE' (or 'TTL') and 'N3'. Default
-                     'TURTLE'
- -h,--help           prints this message
- -p,--port <arg>     launch the SPARQL endpoint on this port
+usage: sparql-endpoint [file1 [file2 ...] [-h] [-p <arg>]
+ -h,--help         prints this message
+ -p,--port <arg>   launch the SPARQL endpoint on this port
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ mvn package assembly:single
 ## Run
 ```
 java -jar target/sparql-endpoint-0.0.1-SNAPSHOT-jar-with-dependencies.jar -h
-usage: sparql-endpoint [file1.ttl [file2.ttl]] [-h] [-p <arg>]
- -h,--help         prints this message
- -p,--port <arg>   launch the SPARQL endpoint on this port
+usage: sparql-endpoint [file1 [file2 ...] [-f <arg>] [-h] [-p <arg>]
+ -f,--format <arg>   the format of the files. One of 'RDF/XML',
+                     'N-TRIPLE', 'TURTLE' (or 'TTL') and 'N3'. Default
+                     'TURTLE'
+ -h,--help           prints this message
+ -p,--port <arg>     launch the SPARQL endpoint on this port
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,15 @@
           </descriptorRefs>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+            <source>6</source>
+            <target>1.6</target>
+        </configuration>
+    </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/be/ugent/webdev/SparqlEndpoint.java
+++ b/src/main/java/be/ugent/webdev/SparqlEndpoint.java
@@ -30,7 +30,6 @@ public class SparqlEndpoint {
 		final Options options = new Options();
 		options.addOption("h", "help", false, "prints this message");
 		options.addOption("p", "port", true, "launch the SPARQL endpoint on this port");
-		options.addOption("f", "format", true, "the format of the files. One of 'RDF/XML', 'N-TRIPLE', 'TURTLE' (or 'TTL') and 'N3'. Default 'TURTLE'");
 		CommandLine arguments = null;
 		try {
 			arguments = new PosixParser().parse(options, args, false);
@@ -44,16 +43,13 @@ public class SparqlEndpoint {
 			formatter.printHelp("sparql-endpoint [file1 [file2 ...]", options, true);
 			System.exit(1);
 		}
-
-		// Parse the file format
-		final String format = arguments.getOptionValue("format", "TURTLE").toUpperCase();
-
+		
 		// Load the files
 		final SparqlEndpoint endpoint = new SparqlEndpoint();
 		for (final String file : arguments.getArgs()) {
-			System.err.format("Reading %s file %s\n", format, file);
+			System.err.format("Reading file %s\n", file);
 			try {
-				endpoint.loadDataset(file, format);
+				endpoint.loadDataset(file);
 			}
 			catch (Exception error) {
 				System.err.format("Could not load %s: %s\n", file, error.getMessage());
@@ -70,8 +66,8 @@ public class SparqlEndpoint {
 		model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM_RULE_INF);
 	}
 	
-	public void loadDataset(final String url, final String format) {
-		model.read(url, format);
+	public void loadDataset(final String url) {
+		model.read(url);
 	}
 	
 	public void start(final int port) {

--- a/src/main/java/be/ugent/webdev/SparqlEndpoint.java
+++ b/src/main/java/be/ugent/webdev/SparqlEndpoint.java
@@ -41,8 +41,7 @@ public class SparqlEndpoint {
 		}
 		if (arguments.hasOption("help")) {
 			final HelpFormatter formatter = new HelpFormatter();
-			formatter.setArgName("file.ttl");
-			formatter.printHelp("sparql-endpoint [file1.ttl [file2.ttl]]", options, true);
+			formatter.printHelp("sparql-endpoint [file1 [file2 ...]", options, true);
 			System.exit(1);
 		}
 

--- a/src/main/java/be/ugent/webdev/SparqlEndpoint.java
+++ b/src/main/java/be/ugent/webdev/SparqlEndpoint.java
@@ -30,6 +30,7 @@ public class SparqlEndpoint {
 		final Options options = new Options();
 		options.addOption("h", "help", false, "prints this message");
 		options.addOption("p", "port", true, "launch the SPARQL endpoint on this port");
+		options.addOption("f", "format", true, "the format of the files. One of 'RDF/XML', 'N-TRIPLE', 'TURTLE' (or 'TTL') and 'N3'. Default 'TURTLE'");
 		CommandLine arguments = null;
 		try {
 			arguments = new PosixParser().parse(options, args, false);
@@ -44,13 +45,16 @@ public class SparqlEndpoint {
 			formatter.printHelp("sparql-endpoint [file1.ttl [file2.ttl]]", options, true);
 			System.exit(1);
 		}
-		
+
+		// Parse the file format
+		final String format = arguments.getOptionValue("format", "TURTLE").toUpperCase();
+
 		// Load the files
 		final SparqlEndpoint endpoint = new SparqlEndpoint();
 		for (final String file : arguments.getArgs()) {
-			System.err.format("Reading Turtle file %s\n", file);
+			System.err.format("Reading %s file %s\n", format, file);
 			try {
-				endpoint.loadDataset(file, "TURTLE");
+				endpoint.loadDataset(file, format);
 			}
 			catch (Exception error) {
 				System.err.format("Could not load %s: %s\n", file, error.getMessage());

--- a/test.rdf
+++ b/test.rdf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:ns0="http://example.org/#">
+
+  <rdf:Description rdf:about="http://example.org/#Person">
+    <owl:equivalentClass rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://example.org/#name">
+    <rdfs:subPropertyOf rdf:resource="http://xmlns.com/foaf/0.1/name"/>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://example.org/#Albert">
+    <rdf:type rdf:resource="http://example.org/#Person"/>
+    <ns0:name>Albert Einstein</ns0:name>
+  </rdf:Description>
+
+  <ns0:Person rdf:about="http://example.org/#Alfred">
+    <ns0:name>Alfred Einstein</ns0:name>
+  </ns0:Person>
+
+</rdf:RDF>


### PR DESCRIPTION
Add a 'format' option, so not only Turtle (.ttl) files can be used.

The [`read`](http://loopasam.github.io/jena-doc/documentation/javadoc/jena/com/hp/hpl/jena/rdf/model/Model.html#read(java.lang.String,%20java.lang.String)) function that is used, supports the formats 'RDF/XML', 'N-TRIPLE', 'TURTLE' (or 'TTL') and 'N3'.

It looks like Jena does not care about the format though. When the server is started with arguments `test.ttl --format rdf/xml`, the Turtle file is read succesfully and the server works.